### PR TITLE
Refactor deploy model for multiple containers

### DIFF
--- a/pkg/deploy/api/types.go
+++ b/pkg/deploy/api/types.go
@@ -52,9 +52,9 @@ type DeploymentTriggerPolicy struct {
 }
 
 type DeploymentTriggerImageChangeParams struct {
-	RepositoryName string `json:"repositoryName,omitempty" yaml:"repositoryName,omitempty"`
-	Tag            string `json:"tag,omitempty" yaml:"tag,omitempty"`
-	ImageName      string `json:"imageName,omitempty" yaml:"imageName,omitempty"`
+	ContainerNames []string `json:"containerNames,omitempty" yaml:"containerNames,omitempty"`
+	RepositoryName string   `json:"repositoryName,omitempty" yaml:"repositoryName,omitempty"`
+	Tag            string   `json:"tag,omitempty" yaml:"tag,omitempty"`
 }
 
 type DeploymentTriggerType string

--- a/pkg/deploy/api/v1beta1/types.go
+++ b/pkg/deploy/api/v1beta1/types.go
@@ -52,9 +52,9 @@ type DeploymentTriggerPolicy struct {
 }
 
 type DeploymentTriggerImageChangeParams struct {
-	RepositoryName string `json:"repositoryName,omitempty" yaml:"repositoryName,omitempty"`
-	Tag            string `json:"tag,omitempty" yaml:"tag,omitempty"`
-	ImageName      string `json:"imageName,omitempty" yaml:"imageName,omitempty"`
+	ContainerNames []string `json:"containerNames,omitempty" yaml:"containerNames,omitempty"`
+	RepositoryName string   `json:"repositoryName,omitempty" yaml:"repositoryName,omitempty"`
+	Tag            string   `json:"tag,omitempty" yaml:"tag,omitempty"`
 }
 
 type DeploymentTriggerType string

--- a/pkg/deploy/api/validation/validation.go
+++ b/pkg/deploy/api/validation/validation.go
@@ -71,8 +71,8 @@ func validateImageChangeParams(params *deployapi.DeploymentTriggerImageChangePar
 		result = append(result, errors.NewFieldRequired("RepositoryName", ""))
 	}
 
-	if len(params.ImageName) == 0 {
-		result = append(result, errors.NewFieldRequired("ImageName", ""))
+	if len(params.ContainerNames) == 0 {
+		result = append(result, errors.NewFieldRequired("ContainerNames", ""))
 	}
 
 	return result

--- a/pkg/deploy/api/validation/validation_test.go
+++ b/pkg/deploy/api/validation/validation_test.go
@@ -149,7 +149,7 @@ func TestValidateDeploymentConfigMissingFields(t *testing.T) {
 				Triggers: []api.DeploymentTriggerPolicy{
 					{
 						ImageChangeParams: &api.DeploymentTriggerImageChangeParams{
-							ImageName: "foo",
+							ContainerNames: []string{"foo"},
 						},
 					},
 				},
@@ -164,7 +164,7 @@ func TestValidateDeploymentConfigMissingFields(t *testing.T) {
 					{
 						Type: api.DeploymentTriggerOnImageChange,
 						ImageChangeParams: &api.DeploymentTriggerImageChangeParams{
-							ImageName: "foo",
+							ContainerNames: []string{"foo"},
 						},
 					},
 				},
@@ -173,7 +173,7 @@ func TestValidateDeploymentConfigMissingFields(t *testing.T) {
 			errors.ValidationErrorTypeRequired,
 			"Triggers[0].ImageChangeParams.RepositoryName",
 		},
-		"missing Trigger ImageChangeParams.ImageName": {
+		"missing Trigger ImageChangeParams.ContainerNames": {
 			api.DeploymentConfig{
 				Triggers: []api.DeploymentTriggerPolicy{
 					{
@@ -186,7 +186,7 @@ func TestValidateDeploymentConfigMissingFields(t *testing.T) {
 				Template: okDeploymentTemplate(),
 			},
 			errors.ValidationErrorTypeRequired,
-			"Triggers[0].ImageChangeParams.ImageName",
+			"Triggers[0].ImageChangeParams.ContainerNames",
 		},
 		"missing Strategy.Type": {
 			api.DeploymentConfig{


### PR DESCRIPTION
Support targetting multiple containers for deployment image triggers.

Clean up integration with ImageRepositories and add tests.
