### PR TITLE
Fix type registration and storage error handling

### DIFF
--- a/pkg/deploy/api/v1beta1/types.go
+++ b/pkg/deploy/api/v1beta1/types.go
@@ -1,7 +1,7 @@
 package v1beta1
 
 import (
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	api "github.com/GoogleCloudPlatform/kubernetes/pkg/api/v1beta1"
 )
 
 // CustomPodDeploymentStrategy describes a deployment carried out by a custom pod.

--- a/pkg/deploy/config_controller.go
+++ b/pkg/deploy/config_controller.go
@@ -4,7 +4,6 @@ import (
 	"time"
 
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/labels"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/watch"
@@ -70,7 +69,7 @@ func (c *DeploymentConfigController) handle(config *deployapi.DeploymentConfig) 
 	deploy, err := c.shouldDeploy(config)
 	if err != nil {
 		// TODO: better error handling
-		glog.Errorf("Error determining whether to redeploy deploymentConfig %v: %v", config.ID, err)
+		glog.Errorf("Error determining whether to redeploy deploymentConfig %v: %#v", config.ID, err)
 		return err
 	}
 
@@ -89,7 +88,7 @@ func (c *DeploymentConfigController) handle(config *deployapi.DeploymentConfig) 
 func (c *DeploymentConfigController) shouldDeploy(config *deployapi.DeploymentConfig) (bool, error) {
 	deployment, err := c.latestDeploymentForConfig(config)
 	if err != nil {
-		if errors.IsNotFound(err) {
+		if IsNotFoundError(err) {
 			return true, nil
 		} else {
 			return false, err

--- a/pkg/deploy/generator/config_generator.go
+++ b/pkg/deploy/generator/config_generator.go
@@ -2,7 +2,6 @@ package generator
 
 import (
 	"fmt"
-	"github.com/GoogleCloudPlatform/kubernetes/pkg/api/errors"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	"github.com/golang/glog"
 	deploy "github.com/openshift/origin/pkg/deploy"
@@ -50,7 +49,7 @@ func (g *deploymentConfigGenerator) Generate(deploymentConfigID string) (*deploy
 
 	deploymentID := deploy.LatestDeploymentIDForConfig(deploymentConfig)
 	if deployment, err = g.deploymentRegistry.GetDeployment(deploymentID); err != nil {
-		if !errors.IsNotFound(err) {
+		if !deploy.IsNotFoundError(err) {
 			return nil, err
 		}
 	}
@@ -95,6 +94,7 @@ func (g *deploymentConfigGenerator) Generate(deploymentConfigID string) (*deploy
 
 	if deployment == nil {
 		// TODO: Is this a safe assumption?
+		glog.Infof("Setting LatestVersion=1 due to absent deployment for config %s", deploymentConfigID)
 		deploymentConfig.LatestVersion = 1
 	} else if !deploy.PodTemplatesEqual(configPodTemplate, deployment.ControllerTemplate.PodTemplate) {
 		deploymentConfig.LatestVersion += 1

--- a/pkg/deploy/util.go
+++ b/pkg/deploy/util.go
@@ -2,13 +2,13 @@ package deploy
 
 import (
 	"fmt"
-	"hash/adler32"
-	"strconv"
-	"strings"
-
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/api"
 	"github.com/GoogleCloudPlatform/kubernetes/pkg/util"
 	deployapi "github.com/openshift/origin/pkg/deploy/api"
+	"hash/adler32"
+	"regexp"
+	"strconv"
+	"strings"
 )
 
 func LatestDeploymentIDForConfig(config *deployapi.DeploymentConfig) string {
@@ -92,4 +92,13 @@ func HashPodTemplate(t api.PodTemplate) uint64 {
 
 func PodTemplatesEqual(a, b api.PodTemplate) bool {
 	return HashPodTemplate(a) == HashPodTemplate(b)
+}
+
+// IsNotFoundError replaces the upstream errors.IsNotFound function which
+// is incorrectly returning error strings rather than API error types for
+// storage 404's.
+// Upstream fix: https://github.com/GoogleCloudPlatform/kubernetes/pull/1500
+func IsNotFoundError(err error) bool {
+	match, _ := regexp.MatchString("status.*failure.*code.*404", err.Error())
+	return match
 }


### PR DESCRIPTION
- Link the public deploy API to the versioned upstream API package (v1beta1) to
  type system registration
- Work around broken errors.IsNotFound upstream, supposedly fixed by:
  https://github.com/GoogleCloudPlatform/kubernetes/pull/1500
