### PR TITLE
Ignore errors when checking client get results

### DIFF
--- a/hack/deploy-suite/manual.sh
+++ b/hack/deploy-suite/manual.sh
@@ -47,7 +47,9 @@ openshift kube update -h $OS_API deploymentConfigs/hello-deployment-config -c ${
 
 status=''
 for (( i=1 ; i<=5 ; i++ )) ; do
+  set +e
   status=$(openshift kube -h $OS_API --template="{{.State}}" get deployments/hello-deployment-config-1)
+  set -e
   echo "Deployment status: $status"
   if [[ "$status" == "complete" || "$status" == "failed" ]]; then
     break


### PR DESCRIPTION
The client will spew garbage and return non-zero on 404-response
get requests due to an upstream bug, so ignore errors for now.
